### PR TITLE
Impl zero-copy serialization for `Connection::open_new_session`

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -2,8 +2,9 @@
 
 use crate::{
     constants,
-    request::{Fwd, Request},
+    request::{Fwd, Request, SessionZeroCopy},
     shutdown_mux_master::shutdown_mux_master_from,
+    utils::serialize_u32,
     Error, EstablishedSession, Response, Result, Session, Socket,
 };
 
@@ -11,6 +12,7 @@ use std::{
     borrow::Cow,
     convert::TryInto,
     io,
+    io::IoSlice,
     num::{NonZeroU32, Wrapping},
     os::unix::io::RawFd,
     path::Path,
@@ -20,7 +22,7 @@ use sendfd::SendWithFd;
 use serde::{de::DeserializeOwned, Serialize};
 use ssh_format::{from_bytes, Serializer};
 use tokio::{io::AsyncWriteExt, net::UnixStream};
-use tokio_io_utility::read_to_vec_rng;
+use tokio_io_utility::{read_to_vec_rng, write_vectored_all};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum ForwardType {
@@ -39,8 +41,12 @@ pub struct Connection {
     request_id: Wrapping<u32>,
 }
 impl Connection {
-    async fn write(&mut self, value: &Request<'_>) -> Result<()> {
+    fn reset_serializer(&mut self) {
         self.serializer.reset();
+    }
+
+    async fn write(&mut self, value: &Request<'_>) -> Result<()> {
+        self.reset_serializer();
         value.serialize(&mut self.serializer)?;
 
         let n = self.raw_conn.write(self.serializer.get_output()?).await?;
@@ -199,11 +205,51 @@ impl Connection {
 
         let request_id = self.get_request_id();
 
-        self.write(&Request::NewSession {
+        // Prepare to serialize
+        let term = session.term.as_ref().into_inner();
+        let cmd = session.cmd.as_ref().into_inner();
+
+        let term_len: u32 = term
+            .len()
+            .try_into()
+            .map_err(|_| ssh_format::Error::TooLong)?;
+
+        let cmd_len: u32 = cmd
+            .len()
+            .try_into()
+            .map_err(|_| ssh_format::Error::TooLong)?;
+
+        let request = Request::NewSession {
             request_id,
-            session,
-        })
-        .await?;
+            session: SessionZeroCopy {
+                tty: session.tty,
+                x11_forwarding: session.x11_forwarding,
+                agent: session.agent,
+                subsystem: session.subsystem,
+                escape_ch: session.escape_ch,
+                term_len,
+            },
+        };
+
+        // Serialize
+        self.reset_serializer();
+
+        request.serialize(&mut self.serializer)?;
+        let serialized_header = self
+            .serializer
+            .get_output_with_data(term_len + /* len of cmd */ 4 + cmd_len)?;
+        let serialized_cmd_len = serialize_u32(cmd_len);
+
+        // Write them to self.raw_conn
+        let mut io_slices = [
+            IoSlice::new(serialized_header),
+            IoSlice::new(term),
+            IoSlice::new(&serialized_cmd_len),
+            IoSlice::new(cmd),
+        ];
+
+        write_vectored_all(&mut self.raw_conn, &mut io_slices).await?;
+
         for fd in fds {
             self.send_with_fds(&[*fd]).await?;
         }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -158,8 +158,10 @@ impl Connection {
     pub async fn connect<P: AsRef<Path>>(path: P) -> Result<Self> {
         let mut serializer = Serializer::new();
 
-        // All request packets are at least 12 bytes large.
-        serializer.reserve(80);
+        // All request packets are at least 12 bytes large,
+        // and variant [`Request::NewSession`] takes 36 bytes to
+        // serialize.
+        serializer.reserve(36);
 
         Self {
             raw_conn: UnixStream::connect(path).await?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #[cfg(not(unix))]
 compile_error!("This crate can only be used on unix");
 
-mod utils;
 mod connection;
 mod constants;
 mod error;
@@ -10,6 +9,7 @@ mod request;
 mod response;
 mod session;
 mod shutdown_mux_master;
+mod utils;
 
 pub mod default_config;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #[cfg(not(unix))]
 compile_error!("This crate can only be used on unix");
 
+mod utils;
 mod connection;
 mod constants;
 mod error;

--- a/src/request.rs
+++ b/src/request.rs
@@ -8,7 +8,7 @@ use serde::{Serialize, Serializer};
 use typed_builder::TypedBuilder;
 
 #[derive(Copy, Clone, Debug)]
-pub enum Request<'a> {
+pub(crate) enum Request<'a> {
     /// Response with `Response::Hello`.
     Hello { version: u32 },
 
@@ -36,7 +36,7 @@ pub enum Request<'a> {
     /// The client may use this to return its local tty to "cooked" mode.
     NewSession {
         request_id: u32,
-        session: &'a Session<'a>,
+        session: SessionZeroCopy,
     },
 
     /// A server may reply with `Response::Ok`, `Response::RemotePort`,
@@ -91,6 +91,23 @@ impl<'a> Serialize for Request<'a> {
             ),
         }
     }
+}
+
+/// Zero copy version of [`Session`]
+#[derive(Copy, Clone, Debug, Serialize)]
+pub(crate) struct SessionZeroCopy {
+    pub tty: bool,
+
+    pub x11_forwarding: bool,
+
+    pub agent: bool,
+
+    pub subsystem: bool,
+
+    pub escape_ch: char,
+
+    /// len of [`Session::term`].
+    pub term_len: u32,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, TypedBuilder)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,4 @@
+/// Serialize one `u32` as ssh_format.
+pub(crate) fn serialize_u32(int: u32) -> [u8; 4] {
+    int.to_be_bytes()
+}


### PR DESCRIPTION
And [Reduce serializer buffer to 36 bytes](https://github.com/openssh-rust/openssh-mux-client/commit/88585358a558f6b056ff42b3dc1b7b91365ed1c8).

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>