### PR TITLE
Refactor: `Connection::open_new_session_impl`

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -222,7 +222,6 @@ impl Connection {
                 agent: session.agent,
                 subsystem: session.subsystem,
                 escape_ch: session.escape_ch,
-                term_len,
             },
         };
 
@@ -230,14 +229,17 @@ impl Connection {
         self.reset_serializer();
 
         request.serialize(&mut self.serializer)?;
-        let serialized_header = self
-            .serializer
-            .get_output_with_data(term_len + /* len of cmd */ 4 + cmd_len)?;
+        let serialized_header = self.serializer.get_output_with_data(
+            /* len of term */ 4 + term_len + /* len of cmd */ 4 + cmd_len,
+        )?;
+
         let serialized_cmd_len = serialize_u32(cmd_len);
+        let serialized_term_len = serialize_u32(term_len);
 
         // Write them to self.raw_conn
         let mut io_slices = [
             IoSlice::new(serialized_header),
+            IoSlice::new(&serialized_term_len),
             IoSlice::new(term),
             IoSlice::new(&serialized_cmd_len),
             IoSlice::new(cmd),

--- a/src/request.rs
+++ b/src/request.rs
@@ -108,9 +108,6 @@ pub(crate) struct SessionZeroCopy {
     pub subsystem: bool,
 
     pub escape_ch: char,
-
-    /// len of [`Session::term`].
-    pub term_len: u32,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, TypedBuilder)]


### PR DESCRIPTION
Serialize `term_len` manually to avoid confusion.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>