### PR TITLE
Mark `openssh_mux_client_error::Error` as `non_exhaustive`

### DIFF
--- a/crates/mux-client-error/src/lib.rs
+++ b/crates/mux-client-error/src/lib.rs
@@ -4,6 +4,7 @@ use thiserror::Error as ThisError;
 pub use ssh_format_error::Error as SshFormatError;
 
 #[derive(Debug, ThisError)]
+#[non_exhaustive]
 pub enum Error {
     /// Server speaks multiplex protocol other than protocol 4.
     #[error("Server speaks multiplex protocol other than protocol 4.")]


### PR DESCRIPTION
So that we can add new variant to it.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>