### PR TITLE
Feat: Port forwarding closure

### DIFF
--- a/crates/mux-client/src/connection.rs
+++ b/crates/mux-client/src/connection.rs
@@ -724,16 +724,17 @@ mod tests {
         let output_listener = TcpListener::bind(("127.0.0.1", 1234)).await.unwrap();
 
         eprintln!("Requesting port forward");
-        conn0.request_port_forward(
-            ForwardType::Remote,
-            &Socket::UnixSocket { path: path.into() },
-            &Socket::TcpSocket {
-                port: 1234,
-                host: "127.0.0.1".into(),
-            },
-        )
-        .await
-        .unwrap();
+        conn0
+            .request_port_forward(
+                ForwardType::Remote,
+                &Socket::UnixSocket { path: path.into() },
+                &Socket::TcpSocket {
+                    port: 1234,
+                    host: "127.0.0.1".into(),
+                },
+            )
+            .await
+            .unwrap();
 
         eprintln!("Creating remote process");
         let cmd = format!("/usr/bin/socat OPEN:/data,rdonly UNIX-CONNECT:{:#?}", path);

--- a/crates/mux-client/src/connection.rs
+++ b/crates/mux-client/src/connection.rs
@@ -753,7 +753,6 @@ mod tests {
         assert_eq!(DATA, &buffer);
 
         drop(output);
-        drop(output_listener);
         drop(stdios);
 
         eprintln!("Closing port forward");
@@ -768,6 +767,12 @@ mod tests {
             )
             .await
             .unwrap();
+
+        eprintln!("Checking whether the socket is closed");
+        let e = output_listener.accept().await.unwrap_err();
+        assert_eq!(e.kind(), io::ErrorKind::ConnectionRefused);
+
+        drop(output_listener);
 
         eprintln!("Waiting for session to end");
         let session_status = established_session.wait().await.unwrap();

--- a/crates/mux-client/src/connection.rs
+++ b/crates/mux-client/src/connection.rs
@@ -767,7 +767,7 @@ mod tests {
             .unwrap();
 
         eprintln!("Checking whether the forwarded socket is closed");
-        output.read(&mut buffer).await.unwrap();
+        assert_eq!(output.read(&mut buffer).await.unwrap(), 0);
 
         drop(output_listener);
         drop(output);

--- a/crates/mux-client/src/connection.rs
+++ b/crates/mux-client/src/connection.rs
@@ -752,7 +752,6 @@ mod tests {
 
         assert_eq!(DATA, &buffer);
 
-
         eprintln!("Closing port forward");
         conn1
             .close_port_forward(

--- a/crates/mux-client/src/connection.rs
+++ b/crates/mux-client/src/connection.rs
@@ -819,9 +819,6 @@ mod tests {
 
         assert_eq!(DATA, buffer);
 
-        drop(output);
-        drop(stdios);
-
         eprintln!("Closing port forward");
         conn1
             .close_port_forward(
@@ -834,6 +831,12 @@ mod tests {
             )
             .await
             .unwrap();
+
+        eprintln!("Checking whether the forwarded socket is closed");
+        assert_eq!(output.read(&mut buffer).await.unwrap(), 0);
+
+        drop(output);
+        drop(stdios);
 
         eprintln!("Waiting for session to end");
         let session_status = established_session.wait().await.unwrap();

--- a/crates/mux-client/src/connection.rs
+++ b/crates/mux-client/src/connection.rs
@@ -476,10 +476,6 @@ impl Connection {
     }
 
     /// Request for local/remote port forwarding closure.
-    ///
-    /// # Warning
-    ///
-    /// Local port forwarding hasn't been tested yet.
     pub async fn close_port_forward(
         &mut self,
         forward_type: ForwardType,
@@ -722,13 +718,13 @@ mod tests {
     }
     run_test!(test_unordered_open_new_session, test_open_new_session_impl);
 
-    async fn test_remote_socket_forward_impl(mut conn: Connection, mut conn1: Connection) {
+    async fn test_remote_socket_forward_impl(mut conn0: Connection, mut conn1: Connection) {
         let path = Path::new("/tmp/openssh-remote-forward.socket");
 
         let output_listener = TcpListener::bind(("127.0.0.1", 1234)).await.unwrap();
 
         eprintln!("Requesting port forward");
-        conn.request_port_forward(
+        conn0.request_port_forward(
             ForwardType::Remote,
             &Socket::UnixSocket { path: path.into() },
             &Socket::TcpSocket {
@@ -741,7 +737,7 @@ mod tests {
 
         eprintln!("Creating remote process");
         let cmd = format!("/usr/bin/socat OPEN:/data,rdonly UNIX-CONNECT:{:#?}", path);
-        let (established_session, stdios) = create_remote_process(conn, &cmd).await;
+        let (established_session, stdios) = create_remote_process(conn0, &cmd).await;
 
         eprintln!("Waiting for connection");
         let (mut output, _addr) = output_listener.accept().await.unwrap();

--- a/crates/mux-client/src/connection.rs
+++ b/crates/mux-client/src/connection.rs
@@ -760,16 +760,17 @@ mod tests {
         drop(stdios);
 
         eprintln!("Closing port forward");
-        conn1.close_port_forward(
-            ForwardType::Remote,
-            &Socket::UnixSocket { path: path.into() },
-            &Socket::TcpSocket {
-                port: 1234,
-                host: "127.0.0.1".into(),
-            },
-        )
-        .await
-        .unwrap();
+        conn1
+            .close_port_forward(
+                ForwardType::Remote,
+                &Socket::UnixSocket { path: path.into() },
+                &Socket::TcpSocket {
+                    port: 1234,
+                    host: "127.0.0.1".into(),
+                },
+            )
+            .await
+            .unwrap();
 
         eprintln!("Waiting for session to end");
         let session_status = established_session.wait().await.unwrap();

--- a/crates/mux-client/src/connection.rs
+++ b/crates/mux-client/src/connection.rs
@@ -752,8 +752,6 @@ mod tests {
 
         assert_eq!(DATA, &buffer);
 
-        drop(output);
-        drop(stdios);
 
         eprintln!("Closing port forward");
         conn1
@@ -768,11 +766,12 @@ mod tests {
             .await
             .unwrap();
 
-        eprintln!("Checking whether the socket is closed");
-        let e = output_listener.accept().await.unwrap_err();
-        assert_eq!(e.kind(), io::ErrorKind::ConnectionRefused);
+        eprintln!("Checking whether the forwarded socket is closed");
+        output.read(&mut buffer).await.unwrap();
 
         drop(output_listener);
+        drop(output);
+        drop(stdios);
 
         eprintln!("Waiting for session to end");
         let session_status = established_session.wait().await.unwrap();

--- a/crates/mux-client/src/constants.rs
+++ b/crates/mux-client/src/constants.rs
@@ -10,6 +10,7 @@ def_constants!(MUX_MSG_HELLO, 0x00000001);
 def_constants!(MUX_C_NEW_SESSION, 0x10000002);
 def_constants!(MUX_C_ALIVE_CHECK, 0x10000004);
 def_constants!(MUX_C_OPEN_FWD, 0x10000006);
+def_constants!(MUX_C_CLOSE_FWD, 0x10000007);
 def_constants!(MUX_C_STOP_LISTENING, 0x10000009);
 def_constants!(MUX_S_OK, 0x80000001);
 def_constants!(MUX_S_PERMISSION_DENIED, 0x80000002);

--- a/crates/mux-client/src/request.rs
+++ b/crates/mux-client/src/request.rs
@@ -47,6 +47,10 @@ pub(crate) enum Request {
     /// `Request::RemotePort`.
     OpenFwd { request_id: u32, fwd_mode: u32 },
 
+    /// A server may reply with `Response::Ok`, `Response::PermissionDenied`,
+    /// or `Response::Failure`.
+    CloseFwd { request_id: u32, fwd_mode: u32 },
+
     /// A client may request the master to stop accepting new multiplexing requests
     /// and remove its listener socket.
     ///
@@ -85,6 +89,15 @@ impl Serialize for Request {
                 "Request",
                 MUX_C_OPEN_FWD,
                 "OpenFwd",
+                &(*request_id, fwd_mode),
+            ),
+            CloseFwd {
+                request_id,
+                fwd_mode,
+            } => serializer.serialize_newtype_variant(
+                "Request",
+                MUX_C_CLOSE_FWD,
+                "CloseFwd",
                 &(*request_id, fwd_mode),
             ),
             StopListening { request_id } => serializer.serialize_newtype_variant(


### PR DESCRIPTION
Quickly implemented port forwarding closure.

Reference: https://github.com/openssh/openssh-portable/blob/059ed698a47c9af541a49cf754fd09f984ac5a21/PROTOCOL.mux#L189

The request is pretty much the exact same as requesting port forwarding, except that the protocol code is `MUX_C_CLOSE_FWD` (0x10000007) and the server does not return a `MUX_S_REMOTE_PORT`.

I realized that the verb "close" aligns better with the protocol doc's language than "cancel". If this gets merged, on the `openssh` repo, I think I'll rename the APIs (i.e., replace "cancel" with "close").

CC. @NobodyXu 